### PR TITLE
Fix para el preview del admin de la imagen cargada para el popup

### DIFF
--- a/app/code/Mageplaza/BetterPopup/etc/adminhtml/system.xml
+++ b/app/code/Mageplaza/BetterPopup/etc/adminhtml/system.xml
@@ -36,16 +36,10 @@
             </group>
             <group id="what_to_show" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>What to Show</label>
-                <!--<field id="template" translate="label comment button_label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Template</label>
-                    <button_label>Load HTML</button_label>
-                    <frontend_model>Mageplaza\BetterPopup\Block\Adminhtml\System\Config\Template</frontend_model>
-                    <comment>Select a template, then click to Load HTML.</comment>
-                </field>-->
                 <field id="upload_image_id" translate="label comment" type="image" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Content Image</label>
                     <backend_model>Mageplaza\BetterPopup\Model\Config\Backend\Image</backend_model>
-                    <base_url type="media" scope_info="1">media/betterpopup</base_url>
+                    <base_url type="media" scope_info="1">betterpopup</base_url>
                 </field>
                 <field id="html_content" sortOrder="10" type="textarea" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Content</label>


### PR DESCRIPTION
El preview de la imagen cargada para el popup no se mostraba correctamente en las configuraciones del admin, se corrige la ruta para mostrar dicha imagen.